### PR TITLE
Fix typo in registers page

### DIFF
--- a/src/routes/documentation/mips/registers/+page.svelte
+++ b/src/routes/documentation/mips/registers/+page.svelte
@@ -8,6 +8,6 @@
 </svelte:head>
 <Page cropped contentStyle="padding: 1rem; gap: 1rem;">
     <h1>MIPS Registers</h1>
-    <p>The MIPS architecture has 32 general-purpose registers, $HI and $LO registers for multiplication and division, and another 32 for floating point numbers<./p>
+    <p>The MIPS architecture has 32 general-purpose registers, $HI and $LO registers for multiplication and division, and another 32 for floating point numbers.</p>
     <MipsRegistersDocumentation />
 </Page>


### PR DESCRIPTION
# Fix typo in registers page

## Changes
- fix the **/home/runner/work/asm-editor/asm-editor/src/routes/documentation/mips/registers/+page.svelte** 


