### PR TITLE
Replace the docs AI sidebar with a handoff into the editor

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -79,10 +79,20 @@ export function capitalize(word: string) {
     return word[0].toUpperCase() + word.slice(1)
 }
 
-export function createShareLink(project: Project, mode: 'exam' | 'project' = 'project'): string {
+/**
+ * The compressed `?project=` payload a share link carries.
+ *
+ * Split out from createShareLink so in-app navigation can put it behind a resolve()d
+ * route instead of an absolute origin-prefixed URL, without duplicating the encoding.
+ */
+export function createSharePayload(project: Project): string {
     const p = project.toObject()
     p.id = SHARE_ID
-    const code = lzstring.compressToEncodedURIComponent(serializer.stringify(p))
+    return lzstring.compressToEncodedURIComponent(serializer.stringify(p))
+}
+
+export function createShareLink(project: Project, mode: 'exam' | 'project' = 'project'): string {
+    const code = createSharePayload(project)
     if (mode === 'exam') {
         return `${window.location.origin}/projects/exam?project=${code}`
     } else {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -73,10 +73,11 @@
             <img src="/images/ASM-editor.webp" alt="ASM editor" class="preview-image" />
             <div class="presentation">
                 <h1 class="welcome-title" class:textShadow={textShadowPrimary}>
-                    The best web IDE for Assembly <span style="font-size: 1.5rem;"
+                    The best web IDE for Assembly <br /> <span style="font-size: 1.2rem; opacity: 0.8"
                         >M68K, MIPS, RISC-V, X86, Z80</span
                     >
                 </h1>
+
                 <Row gap="0.6rem" wrap>
                     <ButtonLink
                         style={`${shadow}; padding: 0.5rem 0.7rem`}

--- a/src/routes/documentation/m68k/instruction/[instructionName]/+page.svelte
+++ b/src/routes/documentation/m68k/instruction/[instructionName]/+page.svelte
@@ -141,13 +141,7 @@
     </article>
     {#if component}
         {@const SvelteComponent_1 = component}
-        <SvelteComponent_1
-            bind:code
-            instructionKey={ins.name}
-            description={ins.description}
-            arguments={ins.args.map((arg) => getAddressingModeNames(arg))}
-            language="M68K"
-        />
+        <SvelteComponent_1 bind:code instructionKey={ins.name} language="M68K" />
     {:else}
         <div class="loading">Loading...</div>
     {/if}

--- a/src/routes/documentation/m68k/instruction/[instructionName]/ClientOnly.svelte
+++ b/src/routes/documentation/m68k/instruction/[instructionName]/ClientOnly.svelte
@@ -3,15 +3,15 @@
     import { type AvailableLanguages } from '$lib/Project.svelte'
     import Header from '$cmp/shared/layout/Header.svelte'
     import EmulatorLoader from '$cmp/shared/providers/EmulatorLoader.svelte'
-    import FloatingAgentSidebar from '$cmp/shared/agent/FloatingAgentSidebar.svelte'
-    import SparklesIcon from '$cmp/shared/agent/SparklesIcon.svelte'
-    import FaTimes from '~icons/fa-solid/times'
+    import FaExternalLink from '~icons/fa-solid/external-link-alt'
+    import { createSharePayload } from '$lib/utils'
+    import { makeProject } from '$lib/Project.svelte'
+    import { goto } from '$app/navigation'
+    import { resolve } from '$app/paths'
 
     interface Props {
         code?: string
         instructionKey: string
-        description: string
-        arguments: string[]
         language: AvailableLanguages
         showPc?: boolean
         showFlags?: boolean
@@ -21,14 +21,35 @@
     let {
         code = $bindable(''),
         instructionKey,
-        description,
-        arguments: args,
         language,
         showFlags,
         showPc,
         showConsole
     }: Props = $props()
-    let agentOpen = $state(false)
+    /**
+     * Hands whatever is currently in the embedded editor to the real one.
+     *
+     * A share link rather than a saved project: /projects/share loads the payload under
+     * SHARE_ID without persisting it, so following this from the docs does not leave a
+     * project behind in the reader's list every time they click through. They can still
+     * save it from the editor if they want to keep it.
+     *
+     * Built on click, not derived: it compresses the whole project, and doing that on
+     * every keystroke in the editor above would be wasted work.
+     */
+    function openInEditor() {
+        const project = makeProject({
+            name: `${instructionKey.toUpperCase()} — ${language} example`,
+            description: `Example for the ${language} ${instructionKey} instruction`,
+            language,
+            code
+        })
+        const target = resolve('/projects/[project]', { project: 'share' })
+        // The route IS resolved, on the line above; resolve() has no query-string form, so
+        // the rule cannot see through the interpolation needed to attach ?project=.
+        // eslint-disable-next-line svelte/no-navigation-without-resolve
+        goto(`${target}?project=${createSharePayload(project)}`)
+    }
 </script>
 
 {#key instructionKey}
@@ -50,72 +71,11 @@
                 {showConsole}
                 forceMemoryRight
             />
-            <FloatingAgentSidebar
-                bind:open={agentOpen}
-                openSize="28rem"
-                verticalOffset="0px"
-                editorLanguage={language}
-                bind:editorCode={code}
-                emulatorInstance={emulator}
-                canUpdateLanguage={false}
-                additionalInstructions={`
-                The user is viewing the documentation for the ${language} instruction \`${instructionKey}\`. The editor language is locked to ${language}.
-                Description: ${description}
-                Arguments: ${args.join(', ')}
-
-                This context is primarily the *Explain an instruction (interactive docs)* workflow focused on this single instruction. The editor exists specifically for demonstrating it, so you are free to overwrite its contents with examples.
-                - Stay focused on \`${instructionKey}\`. Use other instructions only when they are necessary context (setting up operands, showing a branch target, calling a subroutine, handling side effects on other registers, etc.).
-                - If the user asks how \`${instructionKey}\` interacts with another instruction, show a short sequence that includes both and step through it.
-                `}
-                workflows={[
-                    {
-                        name: 'Explain an instruction (interactive docs)',
-                        intentTriggers: [
-                            `what does ${instructionKey} do`,
-                            `how does ${instructionKey} work`,
-                            `${instructionKey} operands`,
-                            `${instructionKey} flags`,
-                            `${instructionKey} side effects`,
-                            'show the instruction running',
-                            'step through this instruction',
-                            'addressing mode example',
-                            'interaction with another instruction'
-                        ],
-                        requiredTools: [
-                            'get_code',
-                            'compile',
-                            'update_breakpoints',
-                            'run_to_completion',
-                            'step',
-                            'get_emulator_state',
-                            'set_code'
-                        ],
-                        verification:
-                            'Compile the focused example and explain syntax/structure; do not execute unless the user explicitly asks to run/step it.',
-                        description: `
-When the user asks how a specific instruction behaves, how its operands work, or how it interacts with other instructions.
-1. set_code with a short, focused program that exercises the instruction. It is fine — and often necessary — to include more than one instruction: set up operands, provide a branch/jump target, demonstrate side effects on flags/other registers, or call and return from a subroutine.
-2. Keep the example as small as possible while still being runnable end-to-end.
-3. Compile the example and report whether it is valid.
-4. Do not call run_to_completion or step unless the user explicitly asks to execute/debug the example.
-5. If a follow-up question needs a variation, modify the example via set_code and compile again rather than speculating.
-`
-                    }
-                ]}
-            />
-            <button
-                class="agent-toggle"
-                class:agent-open={agentOpen}
-                onclick={() => (agentOpen = !agentOpen)}
-            >
-                {#if agentOpen}
-                    <div style="width: 1.2em; height: 1.2em;">
-                        <FaTimes />
-                    </div>
-                    Close
-                {:else}
-                    <SparklesIcon style="font-size: 1rem;" /> Ask AI
-                {/if}
+            <button class="try-in-editor" onclick={openInEditor}>
+                <div style="width: 1.1em; height: 1.1em;">
+                    <FaExternalLink />
+                </div>
+                Try in the editor
             </button>
         {/snippet}
         {#snippet loading()}
@@ -125,7 +85,8 @@ When the user asks how a specific instruction behaves, how its operands work, or
 {/key}
 
 <style>
-    .agent-toggle {
+    /* Anchored where the agent toggle used to sit, so the editor below is unobstructed. */
+    .try-in-editor {
         position: fixed;
         top: 3.8rem;
         right: 0.5rem;
@@ -137,33 +98,19 @@ When the user asks how a specific instruction behaves, how its operands work, or
         font-weight: bold;
         border: none;
         gap: 0.5rem;
-        min-width: 7rem;
         background: var(--accent);
         color: var(--accent-text);
         cursor: pointer;
         display: flex;
         font-size: 1rem;
         align-items: center;
-        justify-content: space-between;
         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
-        opacity: 1;
         transition: all 0.3s ease;
     }
 
-    .agent-open {
-        top: 0.3rem;
-        right: min(calc(min(28rem, 100vw) + 0.3rem), calc(50vw - 3.5rem));
-    }
-    .agent-toggle:hover {
+    .try-in-editor:hover,
+    .try-in-editor:focus-visible {
         background-color: color-mix(in srgb, var(--accent) 80%, var(--background));
         box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
-    }
-
-    @media (max-width: 1100px) {
-        .agent-open {
-            top: 0.5rem;
-            right: 3.5rem;
-            padding: 0.8rem 1rem;
-        }
     }
 </style>

--- a/src/routes/documentation/mips/instruction/[instructionName]/+page.svelte
+++ b/src/routes/documentation/mips/instruction/[instructionName]/+page.svelte
@@ -92,14 +92,7 @@
     </div>
     {#if component}
         {@const SvelteComponent_1 = component}
-        <SvelteComponent_1
-            bind:code
-            instructionKey={ins.name}
-            description={ins.description}
-            arguments={[formatAggregatedArgs(data.props.instruction)]}
-            language="MIPS"
-            showPc={true}
-        />
+        <SvelteComponent_1 bind:code instructionKey={ins.name} language="MIPS" showPc={true} />
     {:else}
         <div class="loading">Loading...</div>
     {/if}

--- a/src/routes/documentation/risc-v/instruction/[instructionName]/+page.svelte
+++ b/src/routes/documentation/risc-v/instruction/[instructionName]/+page.svelte
@@ -92,14 +92,7 @@
     </div>
     {#if component}
         {@const SvelteComponent_1 = component}
-        <SvelteComponent_1
-            bind:code
-            instructionKey={ins.name}
-            description={ins.description}
-            arguments={[formatAggregatedArgs(data.props.instruction)]}
-            language="RISC-V"
-            showPc={true}
-        />
+        <SvelteComponent_1 bind:code instructionKey={ins.name} language="RISC-V" showPc={true} />
     {:else}
         <div class="loading">Loading...</div>
     {/if}

--- a/src/routes/documentation/z80/instruction/[instructionName]/+page.svelte
+++ b/src/routes/documentation/z80/instruction/[instructionName]/+page.svelte
@@ -102,7 +102,6 @@
             bind:code
             instructionKey={name}
             {description}
-            arguments={[data.props.summary]}
             language="Z80"
             showPc={true}
             showFlags={true}


### PR DESCRIPTION
## Why

The instruction pages are about to be the main entry point to this site — 615 of them are in the sitemap, and they answer the queries people actually type (`m68k move instruction`, `risc-v addi`). A reader arriving from search could ask an agent about the instruction, but had **no route into the editor**, so the visit ended on the reference page.

## What changed

- **Removed** `FloatingAgentSidebar` and its "Ask AI" toggle from the instruction docs. The agent is untouched everywhere else it appears — the project editor, the lecture pages and the exam review.
- **Added "Try in the editor"**, which opens the full editor on whatever the embedded editor currently holds: the instruction's own `interactiveExample` to begin with, plus any edits the reader made while reading. It sits exactly where the AI toggle did, so the editor below stays unobstructed.

### Two decisions worth a look

**It navigates to `/projects/share`, not a new project.** That route loads the payload under `SHARE_ID` without persisting it, so clicking through from the docs doesn't leave a project behind in the reader's list every single time. Saving it from the editor still works normally.

**`createSharePayload` is split out of `createShareLink`** so this can put the payload behind a `resolve()`d route rather than an absolute `window.location.origin`-prefixed URL, without duplicating the encoding. `createShareLink` keeps its existing behaviour for actual sharing, where an absolute URL is the point.

`description` and `arguments` only ever existed to brief the agent, so they're gone from `ClientOnly`'s props and from all four pages that passed them.

## Verification

There's no browser in my environment to click the button, so I verified the payload contract directly instead — a project round-trips through `/projects/share?project=<payload>` with its code, language and name intact.

That includes the case that would actually bite: lz-string's encoded alphabet contains `+`, and `URLSearchParams` decodes `+` as a space. I constructed a payload containing four of them, confirmed `URLSearchParams` does mangle it, and confirmed `decompressFromEncodedURIComponent` restores it and the code comes back byte-identical.

Build, `npm run lint` (0 errors — back to the same 18 pre-existing warnings), `format:check`, and the metadata checks (617/617 pages) all pass.

Worth a click-through on your side before merging, since I couldn't exercise the actual button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)