### PR TITLE
Prerender the embed route so it answers 200

### DIFF
--- a/src/routes/embed/+layout.ts
+++ b/src/routes/embed/+layout.ts
@@ -1,3 +1,8 @@
-export const prerender = false
+// Prerendered as an empty shell: the route has to exist as a real file so it answers 200.
+// adapter-static's fallback is 404.html, so a non-prerendered route is served with a 404
+// status — which still renders here, but breaks link checkers and any LMS that validates
+// a URL before framing it. Everything the page needs (code, testcases, panel settings)
+// is read from the query string on mount, so there is nothing to render on the server.
+export const prerender = true
 export const ssr = false
 export const csr = true


### PR DESCRIPTION
`/embed` returns **HTTP 404** in production: https://asm-editor.specy.app/embed

`adapter-static` is configured with `fallback: '404.html'`, and `src/routes/embed/+layout.ts` set `prerender = false`. So the route had no file of its own and Cloudflare served the fallback — which hydrates and routes client-side, so the page *looks* fine in a browser. That's why it went unnoticed. The status code is still 404.

That matters for the one route whose entire purpose is being embedded by someone else: link checkers, Moodle and anything that validates a URL before framing it treat the route as dead, and it can't be linked from course material with any confidence.

## The change

One line — `prerender = true`, with `ssr = false` kept as-is. The page already reads its code, testcases and panel settings from the query string in `onMount`, so there is nothing to render on the server; prerendering just emits the shell as a real file.

The served bytes are equivalent to the fallback it was already getting. Verified `build/404.html` also carries no `<title>`, so hydration behaviour is unchanged — only the status code differs.

## Verified

- `build/embed.html` is emitted, 6829 bytes, distinct from `404.html`
- `/embed` still absent from `sitemap.xml` — this doesn't turn it into a search landing page, it only stops it claiming to be missing
- 618 pages pass the metadata invariants. `embed.html` is excluded from that check: with `ssr = false` the shell has no server-rendered head by design, so title/canonical/h1 assertions don't apply to it
- `format:check` clean, `lint` 0 errors / 18 pre-existing warnings
- Scope confirmed unchanged: `/chat`, `/exam` and `/projects/share` are still not prerendered

## Not fixed here

Those three routes have the identical defect and also return 404 live. `/projects/share` is the notable one — it's where the "Try in the editor" button from #68 navigates, and where every share link lands. Left alone deliberately, since `/exam` and `/chat` may be non-prerendered on purpose; happy to do them in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)